### PR TITLE
Highlight IP position on memory map

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,6 +19,36 @@ def test_extract_hex_bytes_handles_varied_formats() -> None:
     assert main._extract_hex_bytes(sample, 8) == [0x41, 0x07, 0x43, 0x1F, 0x50, 0xAA, 0xBB, 0xCC]
 
 
+def test_parse_register_dump_extracts_segment_base() -> None:
+    dump = """
+EAX=00000001 EBX=00000002
+CS =0000 000f0000 0000ffff 00c09b00
+EIP=00007c00
+"""
+
+    regs = main.parse_register_dump(dump)
+
+    assert regs["EAX"] == 0x1
+    assert regs["EBX"] == 0x2
+    assert regs["EIP"] == 0x7C00
+    assert regs["CS"] == 0x0
+    assert regs["CS_BASE"] == 0x000F0000
+
+
+def test_compute_pointer_address_uses_segment_base() -> None:
+    regs = {"EIP": 0x7C00, "CS_BASE": 0x000F0000}
+    spec = main.RegisterPointerSpec(label="IP", offset_keys=("EIP",), segment="CS")
+
+    assert main.compute_pointer_address(regs, spec) == 0x000F7C00
+
+
+def test_compute_pointer_address_falls_back_to_selector_shift() -> None:
+    regs = {"IP": 0x1234, "CS": 0xF000}
+    spec = main.RegisterPointerSpec(label="IP", offset_keys=("IP",), segment="CS")
+
+    assert main.compute_pointer_address(regs, spec) == (0xF000 << 4) + 0x1234
+
+
 def test_qmp_read_b800_pads_to_expected_size() -> None:
     sample = "0x0000000000000000: 0x41 0x07 0x42 0x17"
     qmp = DummyQMP(sample)


### PR DESCRIPTION
## Summary
- add utilities to parse QEMU register dumps and compute register-backed pointers
- render a highlighted marker and label on the memory map for the current instruction pointer
- cover the new helpers with unit tests to keep register parsing and address math reliable

## Testing
- pytest -o addopts=


------
https://chatgpt.com/codex/tasks/task_e_68c94ae7dc108333afcec581aed89ab2